### PR TITLE
Monk: Add Monk Kit on v5 branch

### DIFF
--- a/Dockerfile.coreui-free-react-admin-template
+++ b/Dockerfile.coreui-free-react-admin-template
@@ -1,0 +1,26 @@
+# Use an official Node runtime as a parent image
+FROM node:14-alpine
+
+# Set the working directory in the container
+WORKDIR /usr/src/app
+
+# Copy package.json and package-lock.json
+COPY package*.json ./
+
+# Install any needed packages specified in package.json
+RUN npm install
+
+# Bundle app source
+COPY . .
+
+# Build the app
+RUN npm run build
+
+# Install serve to serve the build directory
+RUN npm install -g serve
+
+# Inform Docker that the container is listening on the specified port at runtime.
+EXPOSE 3000
+
+# Run serve when the container launches
+CMD ["serve", "-s", "build", "-l", "3000"]

--- a/MANIFEST
+++ b/MANIFEST
@@ -1,0 +1,2 @@
+REPO coreui-free-react-admin-template
+LOAD monk.yaml

--- a/monk.yaml
+++ b/monk.yaml
@@ -1,0 +1,28 @@
+namespace: coreui-free-react-admin-template
+
+coreui-free-react-admin-template:
+  defines: runnable
+  metadata:
+    name: coreui-free-react-admin-template
+    description: A standalone frontend React application for admin dashboard templates.
+    icon: https://emojiapi.dev/api/v1/robot.svg
+  containers:
+    coreui-free-react-admin-template:
+      image: env-3265.registry.local/coreui-free-react-admin-template:v5-e506dd2
+      build: .
+      dockerfile: Dockerfile.coreui-free-react-admin-template
+  services:
+    react-dev-server:
+      description: Development server for React application
+      container: coreui-free-react-admin-template
+      port: 3000
+      host-port: 3000
+      publish: true
+      protocol: tcp
+  connections: {}
+  variables: {}
+
+stack:
+  defines: group
+  members:
+    - coreui-free-react-admin-template/coreui-free-react-admin-template


### PR DESCRIPTION
# Containerization and Deployment Configuration for CoreUI Free React Admin Template

This PR introduces the necessary Docker and Monk.io configurations for the CoreUI Free React Admin Template, a standalone frontend React application. The application is designed to run without any backend services or databases, and listens on port 3000.

### Dockerfile Creation
I created a Dockerfile named `Dockerfile.coreui-free-react-admin-template` to containerize the application. The Dockerfile is based on the Node.js 14-alpine image and includes steps to set up the working directory, install dependencies, and build the application using `react-scripts build`. It also globally installs the `serve` package to serve the built application on port 3000. The container has been tested and is accepting connections at `http://localhost:3000`, indicating that it is configured correctly and running as expected.

### Monk.io Configuration
Alongside the Dockerfile, I added a `monk.yaml` file containing the Monk.io configuration and a `MANIFEST` file listing all files with Monk configurations. These files are essential for deploying the application using Monk.io.

### Configuration Review
I have reviewed the repository, including the `README.md`, `public/`, and `src/` directories, and confirmed that there are no environment variables, connections to other services, or additional ports required beyond port 3000. The application is set up to run in isolation and does not require any further configuration at this time.

### Next Steps
The work on containerizing and writing deployment configuration for the CoreUI Free React Admin Template is complete. The application is ready to be re-deployed on each subsequent push. To proceed, simply merge this PR.

If you have any questions or require further assistance, please feel free to reach out.